### PR TITLE
Fix - resizing logo.ico

### DIFF
--- a/modules/packager/src/main/scala/packager/windows/DefaultImageResizer.scala
+++ b/modules/packager/src/main/scala/packager/windows/DefaultImageResizer.scala
@@ -14,7 +14,9 @@ case object DefaultImageResizer extends ImageResizer {
 
   def generateIcon(logoPath: os.Path, workDirPath: os.Path): os.Path = {
     val icoTmpPath = workDirPath / "logo_tmp.ico"
-    val iconImage: BufferedImage = ImageIO.read(new File(logoPath.toString()));
+    val resizedLogoPath = resizeLogo(logoPath, 32, 32, workDirPath)
+    val iconImage: BufferedImage =
+      ImageIO.read(new File(resizedLogoPath.toString()));
     ICOEncoder.write(iconImage, new File(icoTmpPath.toString()));
     val icoPath = workDirPath / "logo.ico"
     os.copy.over(icoTmpPath, icoPath)

--- a/modules/packager/src/test/scala/packager/TestUtils.scala
+++ b/modules/packager/src/test/scala/packager/TestUtils.scala
@@ -17,7 +17,7 @@ object TestUtils {
   def logo(tmpDir: os.Path): os.Path = {
     val logoPath = tmpDir / "logo.png"
     val logo: BufferedImage =
-      new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB)
+      new BufferedImage(231, 250, BufferedImage.TYPE_INT_ARGB)
     ImageIO.write(logo, "png", new File(logoPath.toString()))
     logoPath
   }


### PR DESCRIPTION
For some sizes logo.png, generating icon ended with following [error](https://github.com/VirtusLab/scala-cli/pull/151#issuecomment-927674712 
).