### PR TITLE
Rollback CI to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          OS: [ubuntu-latest, macos-latest, windows-latest]
+          OS: ["ubuntu-20.04", macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -29,7 +29,7 @@ jobs:
   publish:
     needs: test
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-20.04"
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
CI is failures on `ubuntu-latest` after the upgrade to version `22.04`. We are currently attempting a rollback to version `20.04`.