### PR TITLE
Fix `case-app` initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         apps: 'sbt'
     - name: Test
       run: sbt +test
+    - name: Print help
+      run: sbt "cli/run --help"
 
   publish:
     needs: test

--- a/modules/cli/src/main/scala/packager/cli/PackagerCli.scala
+++ b/modules/cli/src/main/scala/packager/cli/PackagerCli.scala
@@ -1,18 +1,17 @@
 package packager.cli
 
-import caseapp.core.app.CommandsEntryPoint
+import caseapp.core.app.{Command, CommandsEntryPoint}
 import packager.cli.commands.Build
 
 object PackagerCli extends CommandsEntryPoint {
 
-  final override def defaultCommand = Some(Build)
+  final override def defaultCommand: Option[Command[_]] = Some(Build)
 
   override def enableCompleteCommand    = true
   override def enableCompletionsCommand = true
 
-  val commands = Seq(
-    Build
-  )
+  def commands: Seq[Command[_]] =
+    Seq(Build)
 
   override def progName: String = "packager"
 }

--- a/modules/cli/src/main/scala/packager/cli/commands/Build.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/Build.scala
@@ -3,6 +3,7 @@ package packager.cli.commands
 import caseapp.core.RemainingArgs
 import caseapp.core.app.Command
 import BuildOptions.NativePackagerType._
+import caseapp.core.parser.Parser
 import packager.cli.commands.BuildOptions.PackagerType.Docker
 import packager.config.SharedSettings
 import packager.deb.DebianPackage
@@ -13,6 +14,7 @@ import packager.rpm.RedHatPackage
 import packager.windows.{DefaultImageResizer, WindowsPackage}
 
 object Build extends Command[BuildOptions] {
+  override def name: String = "build"
   override def run(
     options: BuildOptions,
     remainingArgs: RemainingArgs

--- a/modules/cli/src/main/scala/packager/cli/commands/BuildOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/BuildOptions.scala
@@ -107,6 +107,7 @@ object BuildOptions {
     case object Rpm    extends NativePackagerType
   }
 
-  implicit val parser: Parser[BuildOptions] = Parser[BuildOptions]
-  implicit val help: Help[BuildOptions]     = Help[BuildOptions]
+  lazy val parser: Parser[BuildOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[BuildOptions, parser.D] = parser
+  implicit lazy val help: Help[BuildOptions]                      = Help.derive
 }

--- a/modules/cli/src/main/scala/packager/cli/commands/DebianOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/DebianOptions.scala
@@ -54,8 +54,7 @@ final case class DebianOptions(
 }
 
 case object DebianOptions {
-
-  implicit val parser: Parser[DebianOptions] = Parser[DebianOptions]
-  implicit val help: Help[DebianOptions]     = Help[DebianOptions]
-
+  lazy val parser: Parser[DebianOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[DebianOptions, parser.D] = parser
+  implicit lazy val help: Help[DebianOptions]                      = Help.derive
 }

--- a/modules/cli/src/main/scala/packager/cli/commands/DockerOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/DockerOptions.scala
@@ -58,7 +58,8 @@ final case class DockerOptions(
 
 case object DockerOptions {
 
-  implicit val parser: Parser[DockerOptions] = Parser[DockerOptions]
-  implicit val help: Help[DockerOptions]     = Help[DockerOptions]
+  lazy val parser: Parser[DockerOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[DockerOptions, parser.D] = parser
+  implicit lazy val help: Help[DockerOptions]                      = Help.derive
 
 }

--- a/modules/cli/src/main/scala/packager/cli/commands/MacOSOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/MacOSOptions.scala
@@ -22,8 +22,7 @@ final case class MacOSOptions(
 }
 
 case object MacOSOptions {
-
-  implicit val parser: Parser[MacOSOptions] = Parser[MacOSOptions]
-  implicit val help: Help[MacOSOptions]     = Help[MacOSOptions]
-
+  lazy val parser: Parser[MacOSOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[MacOSOptions, parser.D] = parser
+  implicit lazy val help: Help[MacOSOptions]                      = Help.derive
 }

--- a/modules/cli/src/main/scala/packager/cli/commands/RedHatOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/RedHatOptions.scala
@@ -40,8 +40,7 @@ final case class RedHatOptions(
 }
 
 case object RedHatOptions {
-
-  implicit val parser: Parser[RedHatOptions] = Parser[RedHatOptions]
-  implicit val help: Help[RedHatOptions]     = Help[RedHatOptions]
-
+  lazy val parser: Parser[RedHatOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[RedHatOptions, parser.D] = parser
+  implicit lazy val help: Help[RedHatOptions]                      = Help.derive
 }

--- a/modules/cli/src/main/scala/packager/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/SharedOptions.scala
@@ -32,7 +32,7 @@ final case class SharedOptions(
   logoPath: Option[String] = None
 )
 case object SharedOptions {
-
-  implicit val parser: Parser[SharedOptions] = Parser[SharedOptions]
-  implicit val help: Help[SharedOptions]     = Help[SharedOptions]
+  lazy val parser: Parser[SharedOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[SharedOptions, parser.D] = parser
+  implicit lazy val help: Help[SharedOptions]                      = Help.derive
 }

--- a/modules/cli/src/main/scala/packager/cli/commands/WindowsOptions.scala
+++ b/modules/cli/src/main/scala/packager/cli/commands/WindowsOptions.scala
@@ -62,7 +62,7 @@ final case class WindowsOptions(
 }
 
 case object WindowsOptions {
-
-  implicit val parser: Parser[WindowsOptions] = Parser[WindowsOptions]
-  implicit val help: Help[WindowsOptions]     = Help[WindowsOptions]
+  lazy val parser: Parser[WindowsOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[WindowsOptions, parser.D] = parser
+  implicit lazy val help: Help[WindowsOptions]                      = Help.derive
 }


### PR DESCRIPTION
This fixes the `scala-packager` CLI failing on init with:
```scala
[error] java.lang.NullPointerException: Cannot invoke "caseapp.core.help.Help.progName()" because the return value of "caseapp.core.app.CaseApp.help()" is null
[error] 	at caseapp.core.app.CaseApp.name(CaseApp.scala:[14](https://github.com/VirtusLab/scala-packager/actions/runs/11972808082/job/33380448142?pr=195#step:6:15))
[error] 	at caseapp.core.app.Command.names(Command.scala:9)
[error] 	at caseapp.core.commandparser.RuntimeCommandParser$.$anonfun$commandMap$1(RuntimeCommandParser.scala:30)
[error] 	at scala.collection.immutable.List.flatMap(List.scala:294)
[error] 	at scala.collection.immutable.List.flatMap(List.scala:79)
[error] 	at caseapp.core.commandparser.RuntimeCommandParser$.commandMap(RuntimeCommandParser.scala:29)
[error] 	at caseapp.core.commandparser.RuntimeCommandParser$.parse(RuntimeCommandParser.scala:47)
[error] 	at caseapp.core.app.CommandsEntryPoint.main(CommandsEntryPoint.scala:369)
[error] 	at packager.cli.PackagerCli.main(PackagerCli.scala)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
```

We'll also run the CLI straight from SBT on the CI as a sanity check (the actual integration checks are in the Scala CLI repo, but we do need a sanity check here).