### PR TITLE
Bump GitHub Linux CI runners to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          OS: [ubuntu-22.04, macos-13, macos-latest, windows-latest]
+          OS: [ubuntu-24.04, macos-13, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -32,7 +32,7 @@ jobs:
   publish:
     needs: test
     if: github.event_name == 'push'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          OS: ["ubuntu-20.04", macos-13, macos-latest, windows-latest]
+          OS: [ubuntu-22.04, macos-13, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -32,7 +32,7 @@ jobs:
   publish:
     needs: test
     if: github.event_name == 'push'
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/modules/image-resizer/src/test/scala/packager/windows/WindowsPackageTests.scala
+++ b/modules/image-resizer/src/test/scala/packager/windows/WindowsPackageTests.scala
@@ -8,7 +8,7 @@ import scala.util.Properties
 
 class WindowsPackageTests extends munit.FunSuite with NativePackageHelper {
 
-  override def outputPackagePath: os.Path = tmpDir / s"echo.msi"
+  override def outputPackagePath: os.Path = tmpDir / s"scalafmt.msi"
 
   if (Properties.isWin) {
 

--- a/modules/packager/src/test/scala/packager/NativePackageHelper.scala
+++ b/modules/packager/src/test/scala/packager/NativePackageHelper.scala
@@ -9,7 +9,7 @@ trait NativePackageHelper extends PackagerHelper {
 
   lazy val sharedSettings: SharedSettings =
     SharedSettings(
-      sourceAppPath = echoLauncherPath,
+      sourceAppPath = scalafmtLauncherPath,
       force = true,
       version = "1.0.0",
       workingDirectoryPath = Some(tmpDir),

--- a/modules/packager/src/test/scala/packager/PackagerHelper.scala
+++ b/modules/packager/src/test/scala/packager/PackagerHelper.scala
@@ -3,10 +3,11 @@ package packager
 import packager.config.BuildSettings
 
 trait PackagerHelper {
-  lazy val packageName               = "echo"
-  lazy val tmpDir: os.Path           = TestUtils.tmpUtilDir
-  lazy val echoLauncherPath: os.Path = TestUtils.echoLauncher(tmpDir)
-  lazy val echoNativePath: os.Path   = TestUtils.echoNative(tmpDir)
+  lazy val packageName: String           = "scalafmt"
+  lazy val tmpDir: os.Path               = TestUtils.tmpUtilDir
+  lazy val scalafmtNativePath: os.Path   = TestUtils.scalafmtNative(tmpDir)
+  lazy val scalafmtLauncherPath: os.Path = TestUtils.scalafmtLauncher(tmpDir)
+  lazy val scalafmtVersion: String       = TestUtils.scalafmtVersion
 
   def buildSettings: BuildSettings
 }

--- a/modules/packager/src/test/scala/packager/TestUtils.scala
+++ b/modules/packager/src/test/scala/packager/TestUtils.scala
@@ -5,27 +5,30 @@ import java.io.File
 import javax.imageio.ImageIO
 
 object TestUtils {
+  def scalafmtVersion = "3.9.1"
 
   def tmpUtilDir: os.Path = os.temp.dir(prefix = "scala-packager-tests")
 
-  def echoLauncher(tmpDir: os.Path): os.Path = {
-    val dest = tmpDir / "echo"
-    os.proc("cs", "bootstrap", "-o", dest.toString, "echo-java").call()
+  def scalafmtNative(tmpDir: os.Path): os.Path = {
+    val dest = tmpDir / "scalafmt-native"
+    os.proc(
+      "curl",
+      "-L",
+      "-o",
+      dest,
+      s"https://github.com/scalameta/scalafmt/releases/download/v$scalafmtVersion/scalafmt-x86_64-pc-linux"
+    ).call()
     dest
   }
 
-  def echoNative(tmpDir: os.Path): os.Path = {
-    val dest = tmpDir / "echo-native"
+  def scalafmtLauncher(tmpDir: os.Path): os.Path = {
+    val dest = tmpDir / "scalafmt"
     os.proc(
       "cs",
-      "launch",
-      "io.get-coursier:coursier-cli_2.12:2.1.0-M6-53-gb4f448130",
-      "--",
       "bootstrap",
-      "io.get-coursier:echo_native0.4_2.13:1.0.5",
       "-o",
-      dest,
-      "--native"
+      dest.toString,
+      s"org.scalameta:scalafmt-cli_2.13:$scalafmtVersion"
     ).call()
     dest
   }

--- a/modules/packager/src/test/scala/packager/TestUtils.scala
+++ b/modules/packager/src/test/scala/packager/TestUtils.scala
@@ -3,8 +3,12 @@ package packager
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
+import scala.annotation.tailrec
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 object TestUtils {
+  lazy val isAarch64: Boolean = sys.props.get("os.arch").contains("aarch64")
+
   def scalafmtVersion = "3.9.1"
 
   def tmpUtilDir: os.Path = os.temp.dir(prefix = "scala-packager-tests")

--- a/modules/packager/src/test/scala/packager/deb/DebianPackageTests.scala
+++ b/modules/packager/src/test/scala/packager/deb/DebianPackageTests.scala
@@ -8,7 +8,7 @@ import scala.util.Properties
 
 class DebianPackageTests extends munit.FunSuite with NativePackageHelper {
 
-  override def outputPackagePath: os.Path = tmpDir / s"echo.deb"
+  override def outputPackagePath: os.Path = tmpDir / s"scalafmt.deb"
 
   if (Properties.isLinux) {
     test("should create DEBIAN directory ") {
@@ -19,10 +19,10 @@ class DebianPackageTests extends munit.FunSuite with NativePackageHelper {
 
       val debianDirectoryPath      = tmpDir / "debian"
       val expectedAppDirectoryPath = debianDirectoryPath / "DEBIAN"
-      val expectedEchoLauncherPath =
+      val expectedLauncherPath =
         debianDirectoryPath / "usr" / "share" / "scala" / packageName
       expect(os.isDir(expectedAppDirectoryPath))
-      expect(os.isFile(expectedEchoLauncherPath))
+      expect(os.isFile(expectedLauncherPath))
     }
 
     test("should generate dep package") {
@@ -38,11 +38,11 @@ class DebianPackageTests extends munit.FunSuite with NativePackageHelper {
       val payloadFiles =
         os.proc("dpkg", "--contents", outputPackagePath).call().out.text().trim
       val expectedScriptPath = os.RelPath("usr") / "bin" / packageName
-      val expectedEchoLauncherPath =
+      val expectedLauncherPath =
         os.RelPath("usr") / "share" / "scala" / packageName
 
       expect(payloadFiles contains s"./$expectedScriptPath")
-      expect(payloadFiles contains s"./$expectedEchoLauncherPath")
+      expect(payloadFiles contains s"./$expectedLauncherPath")
     }
 
     test("should override generated dep package") {
@@ -78,11 +78,11 @@ class DebianPackageTests extends munit.FunSuite with NativePackageHelper {
       val payloadFiles =
         os.proc("dpkg", "--contents", outputPackagePath).call().out.text().trim
       val expectedScriptPath = os.RelPath("usr") / "bin" / launcherApp
-      val expectedEchoLauncherPath =
+      val expectedLauncherPath =
         os.RelPath("usr") / "share" / "scala" / launcherApp
 
       expect(payloadFiles contains s"./$expectedScriptPath")
-      expect(payloadFiles contains s"./$expectedEchoLauncherPath")
+      expect(payloadFiles contains s"./$expectedLauncherPath")
     }
 
     test("should contain priority and section flags") {

--- a/modules/packager/src/test/scala/packager/dmg/DmgPackageTests.scala
+++ b/modules/packager/src/test/scala/packager/dmg/DmgPackageTests.scala
@@ -9,7 +9,7 @@ import scala.util.Properties
 
 class DmgPackageTests extends munit.FunSuite with NativePackageHelper {
 
-  override def outputPackagePath: os.Path = tmpDir / s"echo.dmg"
+  override def outputPackagePath: os.Path = tmpDir / s"scalafmt.dmg"
 
   if (Properties.isMac) {
     test("should create app directory for dmg") {
@@ -20,10 +20,10 @@ class DmgPackageTests extends munit.FunSuite with NativePackageHelper {
       dmgPackage.createAppDirectory()
 
       val expectedAppDirectoryPath = tmpDir / s"$packageName.app"
-      val expectedEchoLauncherPath =
+      val expectedLauncherPath =
         expectedAppDirectoryPath / "Contents" / "MacOS" / packageName
       expect(os.isDir(expectedAppDirectoryPath))
-      expect(os.isFile(expectedEchoLauncherPath))
+      expect(os.isFile(expectedLauncherPath))
     }
 
     test("should generate dmg package") {
@@ -49,8 +49,8 @@ class DmgPackageTests extends munit.FunSuite with NativePackageHelper {
 
     test("size dmg package should be similar to the app") {
 
-      val dmgPackage       = DmgPackage(buildSettings)
-      val echoLauncherSize = os.size(echoLauncherPath)
+      val dmgPackage   = DmgPackage(buildSettings)
+      val launcherSize = os.size(scalafmtLauncherPath)
 
       // create dmg package
       dmgPackage.build()
@@ -58,8 +58,8 @@ class DmgPackageTests extends munit.FunSuite with NativePackageHelper {
       expect(os.exists(outputPackagePath))
 
       val dmgPackageSize = os.size(outputPackagePath)
-      // dmgPackageSize < echoLauncherSize +  1Mb
-      expect(dmgPackageSize < echoLauncherSize + (1024 * 1024))
+
+      expect(dmgPackageSize < launcherSize + (1024 * 1024))
     }
   }
 

--- a/modules/packager/src/test/scala/packager/docker/DockerPackageTests.scala
+++ b/modules/packager/src/test/scala/packager/docker/DockerPackageTests.scala
@@ -10,20 +10,20 @@ import scala.util.Properties
 class DockerPackageTests extends munit.FunSuite with PackagerHelper {
 
   private val qualifier  = "latest"
-  private val repository = "echo-scala-packager"
+  private val repository = "scalafmt-scala-packager"
 
   if (Properties.isLinux) {
     test("should build docker image") {
-      val dockerPackage = DockerPackage(echoLauncherPath, buildSettings)
+      val dockerPackage = DockerPackage(scalafmtLauncherPath, buildSettings)
       // build docker image
       dockerPackage.build()
 
       val expectedImage =
         s"$repository:$qualifier"
-      val expectedOutput = "echo"
+      val expectedOutput = s"scalafmt $scalafmtVersion"
 
       val output = os
-        .proc("docker", "run", expectedImage, expectedOutput)
+        .proc("docker", "run", expectedImage, "--version")
         .call(cwd = os.root)
         .out
         .text()
@@ -36,16 +36,16 @@ class DockerPackageTests extends munit.FunSuite with PackagerHelper {
     }
     test("should build docker image with native application") {
       val nativeAppSettings = buildSettings.copy(exec = None)
-      val dockerPackage     = DockerPackage(echoNativePath, nativeAppSettings)
+      val dockerPackage     = DockerPackage(scalafmtNativePath, nativeAppSettings)
       // build docker image
       dockerPackage.build()
 
       val expectedImage =
         s"$repository:$qualifier"
-      val expectedOutput = "echo"
+      val expectedOutput = s"scalafmt $scalafmtVersion"
 
       val output = os
-        .proc("docker", "run", expectedImage, expectedOutput)
+        .proc("docker", "run", expectedImage, "--version")
         .call(cwd = os.root)
         .out
         .text()
@@ -60,7 +60,7 @@ class DockerPackageTests extends munit.FunSuite with PackagerHelper {
 
   override def buildSettings: DockerSettings =
     DockerSettings(
-      from = "adoptopenjdk/openjdk8",
+      from = "eclipse-temurin:8-jdk",
       registry = None,
       repository = repository,
       tag = Some(qualifier),

--- a/modules/packager/src/test/scala/packager/pkg/PkgPackageTests.scala
+++ b/modules/packager/src/test/scala/packager/pkg/PkgPackageTests.scala
@@ -9,7 +9,7 @@ import scala.util.Properties
 
 class PkgPackageTests extends munit.FunSuite with NativePackageHelper {
 
-  override def outputPackagePath: os.Path = tmpDir / s"echo.pkg"
+  override def outputPackagePath: os.Path = tmpDir / s"scalafmt.pkg"
 
   if (Properties.isMac) {
     test("should create app directory") {
@@ -20,10 +20,9 @@ class PkgPackageTests extends munit.FunSuite with NativePackageHelper {
       pkgPackage.createAppDirectory()
 
       val expectedAppDirectoryPath = tmpDir / s"$packageName.app"
-      val expectedEchoLauncherPath =
-        expectedAppDirectoryPath / "Contents" / "MacOS" / packageName
+      val expectedLauncherPath     = expectedAppDirectoryPath / "Contents" / "MacOS" / packageName
       expect(os.isDir(expectedAppDirectoryPath))
-      expect(os.isFile(expectedEchoLauncherPath))
+      expect(os.isFile(expectedLauncherPath))
     }
 
     test("should generate pkg package") {
@@ -42,12 +41,11 @@ class PkgPackageTests extends munit.FunSuite with NativePackageHelper {
         .out
         .text()
         .trim
-      val expectedAppPath = os.RelPath(s"$packageName.app")
-      val expectedEchoLauncherPath =
-        expectedAppPath / "Contents" / "MacOS" / packageName
+      val expectedAppPath      = os.RelPath(s"$packageName.app")
+      val expectedLauncherPath = expectedAppPath / "Contents" / "MacOS" / packageName
 
       expect(payloadFiles contains s"./$expectedAppPath")
-      expect(payloadFiles contains s"./$expectedEchoLauncherPath")
+      expect(payloadFiles contains s"./$expectedLauncherPath")
 
     }
 
@@ -86,12 +84,11 @@ class PkgPackageTests extends munit.FunSuite with NativePackageHelper {
         .out
         .text()
         .trim
-      val expectedAppPath = os.RelPath(s"$packageName.app")
-      val expectedEchoLauncherPath =
-        expectedAppPath / "Contents" / "MacOS" / launcherApp
+      val expectedAppPath      = os.RelPath(s"$packageName.app")
+      val expectedLauncherPath = expectedAppPath / "Contents" / "MacOS" / launcherApp
 
       expect(payloadFiles contains s"./$expectedAppPath")
-      expect(payloadFiles contains s"./$expectedEchoLauncherPath")
+      expect(payloadFiles contains s"./$expectedLauncherPath")
 
     }
 

--- a/modules/packager/src/test/scala/packager/rpm/RedHatPackageTests.scala
+++ b/modules/packager/src/test/scala/packager/rpm/RedHatPackageTests.scala
@@ -8,7 +8,7 @@ import scala.util.Properties
 
 class RedHatPackageTests extends munit.FunSuite with NativePackageHelper {
 
-  override def outputPackagePath: os.Path = tmpDir / s"echo.rpm"
+  override def outputPackagePath: os.Path = tmpDir / s"scalafmt.rpm"
 
   if (Properties.isLinux) {
     test("should create rpmbuild directory ") {
@@ -20,10 +20,9 @@ class RedHatPackageTests extends munit.FunSuite with NativePackageHelper {
 
       val rpmDirectoryPath         = tmpDir / "rpmbuild"
       val expectedAppDirectoryPath = rpmDirectoryPath / "SOURCES"
-      val expectedEchoLauncherPath =
-        expectedAppDirectoryPath / packageName
+      val expectedLauncherPath     = expectedAppDirectoryPath / packageName
       expect(os.isDir(expectedAppDirectoryPath))
-      expect(os.isFile(expectedEchoLauncherPath))
+      expect(os.isFile(expectedLauncherPath))
     }
 
     test("should generate rpm package") {
@@ -39,10 +38,9 @@ class RedHatPackageTests extends munit.FunSuite with NativePackageHelper {
       // list files which will be installed
       val payloadFiles =
         os.proc("rpm", "-qpl", expectedRpmPath).call().out.text().trim
-      val expectedEchoLauncherPath =
-        os.RelPath("usr") / "bin" / packageName
+      val expectedLauncherPath = os.RelPath("usr") / "bin" / packageName
 
-      expect(payloadFiles contains s"/$expectedEchoLauncherPath")
+      expect(payloadFiles contains s"/$expectedLauncherPath")
     }
 
     test("should override generated rpm package") {
@@ -75,10 +73,9 @@ class RedHatPackageTests extends munit.FunSuite with NativePackageHelper {
       // list files which will be installed
       val payloadFiles =
         os.proc("rpm", "-qpl", outputPackagePath).call().out.text().trim
-      val expectedEchoLauncherPath =
-        os.RelPath("usr") / "bin" / launcherApp
+      val expectedLauncherPath = os.RelPath("usr") / "bin" / launcherApp
 
-      expect(payloadFiles contains s"/$expectedEchoLauncherPath")
+      expect(payloadFiles contains s"/$expectedLauncherPath")
     }
   }
 


### PR DESCRIPTION
- bumps Linux jobs to `ubuntu-24.04`
  - purges `coursier/echo` from all tests and replaces it with `scalameta/scalafmt`
  - changes docker builds from `adoptopenjdk/openjdk8` to `eclipse-temurin:8-jdk`, to fulfill `glibc` requirements of Scala Native images
- tags `.dmg` tests as flaky on `macOS` x86_64 (`macos-13`) builds
  - this is caused by flaky `hdiutil` (`aarch64` runners are seemingly unaffected)
  - refer to https://github.com/VirtusLab/scala-cli/pull/2579 and https://github.com/electron-userland/electron-builder/issues/7137